### PR TITLE
add build.zig, cross-platform builds and no Visual Studio dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ out
 .idea
 .vs
 .vscode
+zig-out/
+zig-cache/

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,70 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe = b.addExecutable(.{
+        .name = "CityBuilder",
+        .target = target,
+        .optimize = optimize,
+    });
+    exe.addIncludePath(.{ .path = "include" });
+    exe.addIncludePath(.{ .path = "libs/include" });
+    exe.addCSourceFiles(source_files, flags);
+    exe.linkLibCpp();
+    exe.linkSystemLibrary("shlwapi");
+    exe.linkSystemLibrary("gdi32");
+    exe.linkSystemLibrary("ole32");
+
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+}
+
+const source_files = &[_][]const u8 {
+    "src/Game.cpp",
+    "src/Engine.cpp",
+    "src/Graphics.cpp",
+    "src/GUI.cpp",
+    "src/Image.cpp",
+    "src/Input.cpp",
+    "src/Timer.cpp",
+    "src/Audio.cpp",
+    "src/Tile.cpp",
+    "src/Grid.cpp",
+    "src/Color.cpp",
+    "src/Random.cpp",
+    "src/UnitManager.cpp",
+    "src/Serialization.cpp",
+    "src/Platform.cpp",
+
+    "src/imgui_draw.cpp",
+    "src/imgui_tables.cpp",
+    "src/imgui_widgets.cpp",
+    "src/imgui.cpp",
+};
+
+const flags = &[_][]const u8 {
+    "-std=c++20",
+    "-DBAT_RUN",
+    "-Wall",
+    "-Wextra",
+    "-Wno-c99-designator",
+    "-Wno-reorder-init-list",
+    "-Wno-microsoft-enum-forward-reference",
+    "-Wno-unused-parameter",
+    "-Wno-unused-variable",
+    "-Wno-missing-field-initializers",
+    "-Wno-switch",
+    "-Wno-logical-op-parentheses",
+    "-Wno-deprecated-declarations",
+    "-Wno-missing-braces",
+};

--- a/include/Maths.h
+++ b/include/Maths.h
@@ -3,6 +3,7 @@
 #define _USE_MATH_DEFINES
 #include <math.h>
 #include <cmath>
+#include <numbers>
 
 #ifndef MAX
     #define MAX(a, b) ((a > b) ? a : b)
@@ -26,11 +27,11 @@ namespace MathUtility
     constexpr double epsilon = 0.000001;
 
     // the ratio of the circumference to the radius of a circle, which is equal to 2π
-    constexpr float TAU = 2.0f * M_PI;
+    constexpr float TAU = 2.0f * std::numbers::pi;
 
     inline float DegreesToRadians(float angle)
     {
-        return angle * M_PI / 180;
+        return angle * std::numbers::pi / 180;
     }
 };
 

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -25,8 +25,8 @@
 
 #ifdef _WIN32
     #include <malloc.h> // NOTE: on unix there is no malloc.h, it's in stdlib or something
-    #include <Windows.h> 
-    #include <Shlwapi.h> // Include this header for PathCombine function
+    #include <windows.h>
+    #include <shlwapi.h> // Include this header for PathCombine function
     #pragma comment(lib, "Shlwapi.lib") // Link to the Shlwapi library
 #endif
 

--- a/src/Platform.cpp
+++ b/src/Platform.cpp
@@ -5,8 +5,8 @@
 
 #if defined(_WIN32)
     #include <malloc.h> // NOTE: on unix there is no malloc.h, it's in stdlib or something
-    #include <Windows.h> 
-    #include <Shlwapi.h> // Include this header for PathCombine function
+    #include <windows.h>
+    #include <shlwapi.h> // Include this header for PathCombine function
     #pragma comment(lib, "Shlwapi.lib") // Link to the Shlwapi library
 #elif defined(__APPLE__)
     #include <sys/stat.h>


### PR DESCRIPTION
Cool project!

This adds a build.zig file which enables building this project with a single dependency, zig.  It's a 75 MB download from https://ziglang.org/download.

This removes needing to install Visual Studio which clang++ depends on. You can confirm this by trying to build this project inside "Windows Sandbox".

This also enables cross-compiling from other platforms (i.e. linux/macos). I compiled this on linux for windows via:

    zig build -Dtarget=x86_64-windows

And then I was able to run it on linux with wine64.

P.S. zig defaults to using more "sanitization flags" than clang does by default.  This could mean the game "crashes" if you're executing "undefined behavior".  You can disable these checks by adding more flags like `-fno-sanitize=address`, or you can let the game crash and try to fix the bigs, up to you.